### PR TITLE
Corrected Usage Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,15 +14,7 @@ $ npm --save viktor-nv1-engine
 var NV1Engine = require( "viktor-nv1-engine" ),
 	AudioContext = global.AudioContext || global.webkitAudioContext,
 	store = require( "store" ),
-	dawEngine,
-	patchLibrary;
-
-NV1Engine.create( AudioContext, store, function( dEngine, pLibrary ) {
-
-	dawEngine = dEngine;
-	patchLibrary = pLibrary;
-
-} );
+	{dawEngine, patchLibrary} = NV1Engine.create( AudioContext, store);
 ```
 
 If you want even more control on the init process of the engine, you should check the implementation of the `NV1Engine.create()` function, which right now looks like this:


### PR DESCRIPTION
Since `NV1Engine.create` only takes 2 arguments and returns `{dawEngine, patchLibrary}`, the example in the "Use" section did not work. Corrected the example using destructuring syntax.

Destructuring syntax is ES6, is it ok to use this in the example?